### PR TITLE
Add nplc to gui

### DIFF
--- a/src/psc_datalogger/gui.py
+++ b/src/psc_datalogger/gui.py
@@ -71,14 +71,26 @@ class DataloggerMainWindow(QMainWindow):
         interval_frame.setLayout(interval_layout)
         interval_layout.addWidget(interval_label)
         interval_input = QLineEdit()
-        int_only = QIntValidator()
-        interval_input.setValidator(int_only)
+        interval_input.setValidator(QIntValidator())
         interval_input.textEdited.connect(self.connection_manager.set_interval)
         interval_layout.addWidget(interval_input)
         layout.addWidget(interval_frame)
 
         logfile_widgets = LogFileWidgets(self.connection_manager.set_filepath)
         layout.addWidget(logfile_widgets)
+
+        # Widgets for NPLC
+        nplc_frame = QFrame()
+        nplc_label = QLabel("NPLC:")
+        nplc_layout = QHBoxLayout()
+        nplc_frame.setLayout(nplc_layout)
+        nplc_layout.addWidget(nplc_label)
+        nplc_input = QLineEdit()
+        nplc_input.setText("50")
+        nplc_input.setValidator(QIntValidator())
+        nplc_input.textEdited.connect(self.connection_manager.set_nplc)
+        nplc_layout.addWidget(nplc_input)
+        layout.addWidget(nplc_frame)
 
         # Start/Stop logging buttons
         self.start_text = "Start Logging"
@@ -115,7 +127,7 @@ class DataloggerMainWindow(QMainWindow):
             self.connection_manager.stop_logging()
 
     def handle_instrument_changed(self):
-        """Handle when any of the Agilent GPIB addresses change"""
+        """Handle when any of the instrument configurations change"""
         for i in self.instruments:
             if i.isChecked():
                 address = i.get_address()

--- a/src/psc_datalogger/gui.py
+++ b/src/psc_datalogger/gui.py
@@ -129,22 +129,22 @@ class DataloggerMainWindow(QMainWindow):
     def handle_instrument_changed(self):
         """Handle when any of the instrument configurations change"""
         for i in self.instruments:
-            if i.isChecked():
-                address = i.get_address()
-                measure_temp = i.get_temperature_checked()
-            else:
-                # Blank the address if the widget is disabled
-                address = ""
-                measure_temp = False
+            # if i.isChecked():
+            #     enabled = True
+            #     address = i.get_address()
+            #     measure_temp = i.get_temperature_checked()
+            # else:
+            #     enabled = False
+            #     # Blank the address if the widget is disabled
+            #     address = ""
+            #     measure_temp = False
 
-            try:
-                self.connection_manager.set_instrument(
-                    i.instrument_number, address, measure_temp
-                )
-            except ValueError:
-                # We expect ValueError for uninitialized/previously initialized but now
-                # disabled instruments
-                pass
+            self.connection_manager.set_instrument(
+                i.instrument_number,
+                i.isChecked(),
+                i.get_address(),
+                i.get_temperature_checked(),
+            )
 
 
 class LogFileWidgets(QFrame):

--- a/src/psc_datalogger/gui.py
+++ b/src/psc_datalogger/gui.py
@@ -129,16 +129,6 @@ class DataloggerMainWindow(QMainWindow):
     def handle_instrument_changed(self):
         """Handle when any of the instrument configurations change"""
         for i in self.instruments:
-            # if i.isChecked():
-            #     enabled = True
-            #     address = i.get_address()
-            #     measure_temp = i.get_temperature_checked()
-            # else:
-            #     enabled = False
-            #     # Blank the address if the widget is disabled
-            #     address = ""
-            #     measure_temp = False
-
             self.connection_manager.set_instrument(
                 i.instrument_number,
                 i.isChecked(),

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -177,7 +177,7 @@ class TestWorker:
 
         expected_config = InstrumentConfig(address, measure_temp)
 
-        assert worker.instrument_addresses[num] == expected_config
+        assert worker.instrument_configs[num] == expected_config
         mocked_init_instrument.assert_called_once_with(expected_config)
 
     def test_override_instrument(self, worker: Worker):
@@ -198,7 +198,7 @@ class TestWorker:
         expected_config = InstrumentConfig(address, measure_temp)
         worker.set_instrument(num, str(address), measure_temp)
 
-        assert worker.instrument_addresses[num] == expected_config
+        assert worker.instrument_configs[num] == expected_config
         mocked_init_instrument.assert_called_with(expected_config)
 
     @pytest.mark.parametrize("invalid_value", [-1, 0, 4, 5])
@@ -222,6 +222,8 @@ class TestWorker:
             call("++auto 1"),
             call("PRESET NORM"),
             call("BEEP 0"),
+            call(f"++addr {address}"),
+            call("++auto 1"),
             call("NPLC 50"),
             call("TRIG HOLD"),
         ]
@@ -237,7 +239,7 @@ class TestWorker:
     def test_validate_parameters(self, worker: Worker):
         """Test that validate_parameters allows through valid parameters"""
 
-        worker.instrument_addresses[1] = InstrumentConfig(23)
+        worker.instrument_configs[1] = InstrumentConfig(23)
         worker.interval = 1
         worker.writer = MagicMock()
 
@@ -257,7 +259,7 @@ class TestWorker:
     ):
         """Test that validate_parameters rejects invalid parameters"""
 
-        worker.instrument_addresses[1] = InstrumentConfig(address)
+        worker.instrument_configs[1] = InstrumentConfig(address)
         worker.interval = interval
         worker.writer = writer
 
@@ -427,7 +429,7 @@ class TestWorker:
         """Test querying the (mocked) hardware returns voltage"""
         # Set up mocks
         address = 22
-        worker.instrument_addresses[1] = InstrumentConfig(address)
+        worker.instrument_configs[1] = InstrumentConfig(address)
         voltage_str = " 9.089320482E+00\r\n"
         voltage_trimmed = "9.089320482E+00"
         mocked_write = MagicMock()
@@ -459,7 +461,7 @@ class TestWorker:
         temperature"""
         # Set up mocks
         address = 22
-        worker.instrument_addresses[1] = InstrumentConfig(address, convert_to_temp=True)
+        worker.instrument_configs[1] = InstrumentConfig(address, convert_to_temp=True)
         voltage_str = "1E-03"
         temperature = "0.2"  # degrees Celcius, calculated from voltage_str
         mocked_write = MagicMock()
@@ -490,7 +492,7 @@ class TestWorker:
         """Test that a timeout returns an error string"""
         # Set up mocks
         address = 22
-        worker.instrument_addresses[1] = InstrumentConfig(address)
+        worker.instrument_configs[1] = InstrumentConfig(address)
         mocked_write = MagicMock()
         mocked_query = MagicMock(side_effect=pyvisa.VisaIOError(VI_ERROR_TMO))
         worker.connection = MagicMock()
@@ -520,7 +522,7 @@ class TestWorker:
         returns an error"""
         # Set up mocks
         address = 22
-        worker.instrument_addresses[1] = InstrumentConfig(address, convert_to_temp=True)
+        worker.instrument_configs[1] = InstrumentConfig(address, convert_to_temp=True)
         voltage_str = "12345"
         mocked_write = MagicMock()
         mocked_query = MagicMock(return_value=voltage_str)


### PR DESCRIPTION
This PR adds the "NPLC" configuration item to the main GUI. Previously this value was hard-coded as "50", hence the default value.

As this was previously set during instrument initialization and was never expected to change, this PR required an unexpectedly large amount of restructuring. Main changes include:
- Adding "enabled" to the InstrumentConfig, so that the internal data model now mirrors the GUI's checkboxes
- Refactored `_init_instrument` into sub-functions, to allow re-use for `set_nplc`. 
- Added a bunch of logging and error message handling, so more errors are now visible on the GUI and/or more messages are sent to the logger.

![image](https://github.com/DiamondLightSource/psc-datalogger/assets/79699091/fe7aa4d2-f8eb-4843-ae35-34666144c2f6)
