### PR TITLE
Fix initialization bug

### DIFF
--- a/src/psc_datalogger/connection.py
+++ b/src/psc_datalogger/connection.py
@@ -310,7 +310,7 @@ class Worker(QObject):
             # However we want to ensure we always have at least a 5 second timeout
             # as even the smallest NPLC values seem to take a few seconds to complete
             timeout = max(5000, self.nplc * 100)
-            self._connection_timeout(timeout)  # ms
+            self._set_connection_timeout(timeout)  # ms
 
     def _set_prologix_address(self, gpib_address: int) -> None:
         """Configure the Prologix to point to the given GPIB address"""
@@ -522,28 +522,28 @@ class Worker(QObject):
             raise ConnectionNotInitialized()
 
     def _connection_write(self, command: str) -> None:
-        """Wrapper for all connection write commands."""
+        """Write the given command to the connection"""
         self._connection_check()
         self.connection.write(command)
 
     def _connection_bytes_in_buffer(self) -> int:
-        """Wrapper for accessing connection.bytes_in_buffer"""
+        """Access connection.bytes_in_buffer"""
         self._connection_check()
         return self.connection.bytes_in_buffer
 
     def _connection_read(self) -> str:
-        """Wrapper for all connection read commands."""
+        """Read data from the connection"""
         self._connection_check()
         return self.connection.read()
 
-    def _connection_timeout(self, timeout: int) -> None:
-        """Wrapper for setting connection timeout.
+    def _set_connection_timeout(self, timeout: int) -> None:
+        """Set timeout on the connection.
 
         Timeout is in milliseconds."""
         self._connection_check()
         self.connection.timeout = timeout
 
     def _connection_query(self, command: str) -> str:
-        """Wrapper for all connection query commands."""
+        """Write the given command to the connection and read the result"""
         self._connection_check()
         return self.connection.query(command)

--- a/src/psc_datalogger/connection.py
+++ b/src/psc_datalogger/connection.py
@@ -179,7 +179,7 @@ class Worker(QObject):
 
     # The connection to the Prologix controller. Do not directly access, use the
     # _connection_* wrapper functions.
-    connection: SerialInstrument
+    _connection: SerialInstrument
 
     # Constant to mark a measurement could not be taken. Also written to results file.
     ERROR_STRING = "#ERROR"
@@ -397,7 +397,7 @@ class Worker(QObject):
                 raise PrologixNotFoundException(errmsg)
 
             # The open_resource function returns a very generic type
-            self.connection = cast(SerialInstrument, conn)
+            self._connection = cast(SerialInstrument, conn)
 
             logging.info("Connection initialized")
 
@@ -515,7 +515,7 @@ class Worker(QObject):
 
         Mostly required to guard against potential checks before the Prologix
         controller has connected (or maybe there isn't even one plugged in yet!)"""
-        if not hasattr(self, "connection"):
+        if not hasattr(self, "_connection"):
             logging.warning(
                 "Attempted to write to connection when it was not initialized"
             )
@@ -524,26 +524,26 @@ class Worker(QObject):
     def _connection_write(self, command: str) -> None:
         """Write the given command to the connection"""
         self._connection_check()
-        self.connection.write(command)
+        self._connection.write(command)
 
     def _connection_bytes_in_buffer(self) -> int:
         """Access connection.bytes_in_buffer"""
         self._connection_check()
-        return self.connection.bytes_in_buffer
+        return self._connection.bytes_in_buffer
 
     def _connection_read(self) -> str:
         """Read data from the connection"""
         self._connection_check()
-        return self.connection.read()
+        return self._connection.read()
 
     def _set_connection_timeout(self, timeout: int) -> None:
         """Set timeout on the connection.
 
         Timeout is in milliseconds."""
         self._connection_check()
-        self.connection.timeout = timeout
+        self._connection.timeout = timeout
 
     def _connection_query(self, command: str) -> str:
         """Write the given command to the connection and read the result"""
         self._connection_check()
-        return self.connection.query(command)
+        return self._connection.query(command)

--- a/src/psc_datalogger/connection.py
+++ b/src/psc_datalogger/connection.py
@@ -229,8 +229,9 @@ class Worker(QObject):
         try:
             address = int(gpib_address)
         except ValueError:
-            # May not be an address set in the GUI; if so convert the blank string
-            # to an invalid number
+            # May not be an address set in the GUI; this happens when the "enable"
+            # tickbox is first pressed and the address field is likely empty.
+            logging.info(f"gpib address '{gpib_address}' invalid")
             address = -1
 
         logging.info(

--- a/src/psc_datalogger/gui.py
+++ b/src/psc_datalogger/gui.py
@@ -139,8 +139,9 @@ class DataloggerMainWindow(QMainWindow):
             except ValueError:
                 # Expected when first activating an instrument; the Address field
                 # will be empty
-                logging.exception(
-                    f"ValueError when initializing instrument {i.instrument_number}"
+                logging.warning(
+                    f"Exception when initializing instrument {i.instrument_number}",
+                    exc_info=True,
                 )
 
 

--- a/src/psc_datalogger/gui.py
+++ b/src/psc_datalogger/gui.py
@@ -129,12 +129,19 @@ class DataloggerMainWindow(QMainWindow):
     def handle_instrument_changed(self):
         """Handle when any of the instrument configurations change"""
         for i in self.instruments:
-            self.connection_manager.set_instrument(
-                i.instrument_number,
-                i.isChecked(),
-                i.get_address(),
-                i.get_temperature_checked(),
-            )
+            try:
+                self.connection_manager.set_instrument(
+                    i.instrument_number,
+                    i.isChecked(),
+                    i.get_address(),
+                    i.get_temperature_checked(),
+                )
+            except ValueError:
+                # Expected when first activating an instrument; the Address field
+                # will be empty
+                logging.exception(
+                    f"ValueError when initializing instrument {i.instrument_number}"
+                )
 
 
 class LogFileWidgets(QFrame):

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -249,7 +249,7 @@ class TestWorker:
 
         mocked_connection = MagicMock()
         mocked_connection.bytes_in_buffer = 0
-        worker.connection = mocked_connection
+        worker._connection = mocked_connection
 
         enabled = True
         address = 22
@@ -276,7 +276,7 @@ class TestWorker:
 
         mocked_connection = MagicMock()
         mocked_connection.read = MagicMock(side_effect=["some", "random", "data"])
-        worker.connection = mocked_connection
+        worker._connection = mocked_connection
 
         enabled = True
         address = 22
@@ -314,7 +314,7 @@ class TestWorker:
 
         # Setup
         worker.instrument_configs[1] = InstrumentConfig(True, 5)
-        worker.connection = MagicMock()
+        worker._connection = MagicMock()
 
         nplc = "100"
 
@@ -322,8 +322,8 @@ class TestWorker:
         worker.set_nplc(nplc)
 
         # Check the set NPLC command was set and the timeout was increased
-        worker.connection.write.assert_any_call(f"NPLC {nplc}")
-        assert worker.connection.timeout == 10000
+        worker._connection.write.assert_any_call(f"NPLC {nplc}")
+        assert worker._connection.timeout == 10000
 
     @pytest.mark.parametrize("invalid_value", ["-1", "0", "2001", "999999"])
     def test_set_nplc_invalid_value(self, invalid_value: str, worker: Worker):
@@ -386,7 +386,7 @@ class TestWorker:
 
         worker.init_connection()
 
-        assert worker.connection == mock_conn
+        assert worker._connection == mock_conn
 
     @patch("psc_datalogger.connection.pyvisa.ResourceManager")
     def test_init_connection_no_resources(
@@ -484,7 +484,7 @@ class TestWorker:
         writer"""
 
         # Setup all mocks
-        worker.connection = True  # type: ignore
+        worker._connection = True  # type: ignore
         worker.writer = MagicMock()
         worker.query_complete = MagicMock()
         now = datetime.now()
@@ -504,7 +504,7 @@ class TestWorker:
         """Test do_logging sends an error signal with invalid data"""
 
         # Setup all mocks
-        worker.connection = True  # type: ignore
+        worker._connection = True  # type: ignore
         worker.writer = MagicMock()
         worker.error = MagicMock()
         now = datetime.now()
@@ -532,9 +532,9 @@ class TestWorker:
         voltage_trimmed = "9.089320482E+00"
         mocked_write = MagicMock()
         mocked_query = MagicMock(return_value=voltage_str)
-        worker.connection = MagicMock()
-        worker.connection.write = mocked_write
-        worker.connection.query = mocked_query
+        worker._connection = MagicMock()
+        worker._connection.write = mocked_write
+        worker._connection.query = mocked_query
 
         now = datetime.now()
         mocked_datetime.now.return_value = now
@@ -566,9 +566,9 @@ class TestWorker:
         temperature = "0.2"  # degrees Celcius, calculated from voltage_str
         mocked_write = MagicMock()
         mocked_query = MagicMock(return_value=voltage_str)
-        worker.connection = MagicMock()
-        worker.connection.write = mocked_write
-        worker.connection.query = mocked_query
+        worker._connection = MagicMock()
+        worker._connection.write = mocked_write
+        worker._connection.query = mocked_query
 
         now = datetime.now()
         mocked_datetime.now.return_value = now
@@ -595,9 +595,9 @@ class TestWorker:
         worker.instrument_configs[1] = InstrumentConfig(True, address)
         mocked_write = MagicMock()
         mocked_query = MagicMock(side_effect=pyvisa.VisaIOError(VI_ERROR_TMO))
-        worker.connection = MagicMock()
-        worker.connection.write = mocked_write
-        worker.connection.query = mocked_query
+        worker._connection = MagicMock()
+        worker._connection.write = mocked_write
+        worker._connection.query = mocked_query
 
         now = datetime.now()
         mocked_datetime.now.return_value = now
@@ -628,9 +628,9 @@ class TestWorker:
         voltage_str = "12345"
         mocked_write = MagicMock()
         mocked_query = MagicMock(return_value=voltage_str)
-        worker.connection = MagicMock()
-        worker.connection.write = mocked_write
-        worker.connection.query = mocked_query
+        worker._connection = MagicMock()
+        worker._connection.write = mocked_write
+        worker._connection.query = mocked_query
 
         now = datetime.now()
         mocked_datetime.now.return_value = now


### PR DESCRIPTION
During startup of the application, it attempts to connect to the "Prologix" controller, plugged in via USB port. This is the `connection` object in the `Worker` class. It starts uninitialized, and only gains a value when the "Prologix" controller is found (by trying all possible connected USB devices until something responds appropriately). 

It is possible for users to make changes in the GUI before the equipment is found or, more commonly, before the Prologix controller is plugged in. This triggers an attempt to write the new configuration to the controller.This caused exceptions that were causing the GUI to crash.

Now we explicitly guard the connection object, and raise a specific exception if it is not initialized. This allows the GUI to continue operating.


Note that this can cause an issue where configuration is changed on the GUI, but has not been written to the controller. For example, if all configuration items are set in the GUI before the Prologix controller is connected, and then it is connected, pressing the "start" button may cause logging to begin with unexpected configuration. I'm not sure how much time it is worth committing to fixing this  - it's probably a separate issue anyway.